### PR TITLE
Ram saves

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -147,6 +147,7 @@ fn run_emulator(
                                 let ram = cpu.cart.ram();
                                 let mut cart_title = String::from_utf8(cpu.cart.title.clone()).unwrap();
                                 cart_title.make_ascii_lowercase();
+                                cart_title = cart_title.replace(" ", "_");
                                 let file_name = format!("{}-{}.sav", cart_title, save_num_str);
                                 info!("save slot {}", save_num_str);
                                 let mut f = File::create(file_name).expect("Failed to create file for saving");
@@ -164,6 +165,7 @@ fn run_emulator(
                                 info!("load {}", save_num_str);
                                 let mut cart_title = String::from_utf8(cpu.cart.title.clone()).unwrap();
                                 cart_title.make_ascii_lowercase();
+                                cart_title = cart_title.replace(" ", "_");
                                 let file_name = format!("{}-{}.sav", cart_title, save_num_str);
                                 let ram = std::fs::read(file_name)
                                     .map(|r| r.into_boxed_slice());

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -161,14 +161,13 @@ fn run_emulator(
                                     Keycode::Num0 => "3",
                                     _ => "1"
                                 };
-                                println!("load {}", save_num_str);
+                                info!("load {}", save_num_str);
                                 let mut cart_title = String::from_utf8(cpu.cart.title.clone()).unwrap();
                                 cart_title.make_ascii_lowercase();
                                 let file_name = format!("{}-{}.sav", cart_title, save_num_str);
                                 let ram = std::fs::read(file_name)
                                     .map(|r| r.into_boxed_slice());
                                 if ram.is_ok() {
-                                    info!("loading save file slot: {}", save_num_str);
                                     cpu.cart.set_ram(ram.unwrap());
                                 }
                             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,17 +95,7 @@ fn run(opts: &RunOpts) -> Result<(), failure::Error> {
     let cart_header = CartHeader::from_rom(&rom).context("Failed to parse cartridge header")?;
     let cart_config = CartConfig::from_cart_header(&cart_header)?;
 
-    // TODO(solson): Include some kind of game-identifying information in the save file to
-    // prevent loading a save file with the wrong game.
-    let ram = opts.save_path
-        .as_ref()
-        .and_then(|path| std::fs::read(path).ok())
-        .map(|r| r.into_boxed_slice());
-    if ram.is_some() {
-        info!("Initialized cartridge RAM from file");
-    }
-
-    let cart = Cart::new(rom, ram, &cart_config).context("Failed to initialize cartridge")?;
+    let cart = Cart::new(rom, None, &cart_config).context("Failed to initialize cartridge")?;
     let mut cpu = Cpu::new(cart);
 
     if let Some(path) = &opts.symbols_path {


### PR DESCRIPTION
Add 3 cart ram dump slots to rugby. Initial implementation with lots of room for improvement. The goal is to eventually turn this into a full memory dump.