### PR TITLE
Audio envelopes

### DIFF
--- a/src/audio/channel1.rs
+++ b/src/audio/channel1.rs
@@ -6,7 +6,14 @@ const MAX_SOUND_LENGTH: u8 = 64;
 
 #[derive(Clone)]
 pub struct Channel1 {
-    // TODO(wcarlson): Sweep register
+    /// Sweep time
+    freq_sweep_time: u8,
+
+    /// Direction of frequency shift. bit 3 of 0xFF10. 0 is increase, 1 is decrease
+    freq_direction: u8,
+
+    /// The number of sweep shift. bits 2-0 of 0xFF10
+    freq_sweep: u8,
 
     /// Wave pattern duty. Bits 6-7 of 0xFF11
     wave_pattern: u8,
@@ -28,7 +35,7 @@ pub struct Channel1 {
     envelope_direction: EnvelopeDirection,
 
     /// Number of envelope sweeps. Bits 0-2 of 0xFF12
-    envelope_sweeps: u8,
+    envelope_sweep: u8,
 
     /// Channel frequency. Lower bits are bits 0-7 of 0xFF13. Higher bits are 0-2 of 0xFF14
     /// Actual frequency is given by `(2048 - frequency) * 4`. http://gbdev.gg8.se/wiki/articles/Gameboy_sound_hardware
@@ -63,12 +70,15 @@ impl Channel1 {
     pub fn new() -> Channel1 {
         Channel1 {
             wave_pattern: 0b10,
+            freq_sweep: 0,
+            freq_direction: 0,
+            freq_sweep_time: 0,
             length_counter: MAX_SOUND_LENGTH,
             length_counter_enabled: true,
             initial_volume: 0b11111,
             curr_volume: 0, // TODO: check what this should be for channels 1,2,4
             envelope_direction: EnvelopeDirection::Decrease,
-            envelope_sweeps: 0b11,
+            envelope_sweep: 0b11,
             frequency: 0,
             restart: false,
             stop_after_sound_length: false,
@@ -83,15 +93,16 @@ impl Channel1 {
 
     pub fn read_reg(&self, addr: u8) -> u8 {
         match addr {
-            0x10 => {
-                warn!("unimplemented read from channel 1 audio sweep register");
-                0x80
+            0x10 => { // TODO: what should bit 7 be on read?
+                self.freq_sweep_time << 4
+                    | self.freq_direction << 3
+                    | self.freq_sweep
             }
             0x11 => (self.wave_pattern << 6) | 0b0011_1111, // Low bits are write-only
             0x12 => {
                 self.initial_volume << 4
                     | (self.envelope_direction as u8) << 3
-                    | self.envelope_sweeps
+                    | self.envelope_sweep
             },
             0x13 => 0xFF, // This register is entirely write-only
             0x14 => {
@@ -104,13 +115,17 @@ impl Channel1 {
 
     pub fn write_reg(&mut self, addr: u8, val: u8) {
         match addr {
-            0x10 => warn!("unimplemented write to channel 1 audio sweep register"),
+            0x10 => {
+                self.freq_sweep_time = val >> 4 & 0b0111;
+                self.freq_direction = (val >> 3) & 1;
+                self.freq_sweep = val & 0b0111;
+            },
             0x11 => {
                 self.wave_pattern = val >> 6;
                 self.length_counter = MAX_SOUND_LENGTH - (val & 0b0011_1111);
             },
             0x12 => {
-                self.envelope_sweeps = val & 0b0111;
+                self.envelope_sweep = val & 0b0111;
                 self.envelope_direction = EnvelopeDirection::from((val >> 3) & 1);
                 self.initial_volume = val >> 4;
             },
@@ -127,9 +142,6 @@ impl Channel1 {
                 if self.length_counter == 0 && self.restart {
                     self.length_counter = MAX_SOUND_LENGTH;
                 }
-                // if self.length_counter_enabled {
-                //     self.length_counter = MAX_SOUND_LENGTH
-                // }
                 if self.restart {
                     self.enabled = true;
                     self.curr_volume = self.initial_volume;
@@ -188,12 +200,12 @@ impl Channel1 {
     fn update_volume(&mut self, cycles: usize) {
         if self.curr_volume == 0 && self.envelope_direction == EnvelopeDirection::Decrease ||
             self.curr_volume == 15 && self.envelope_direction == EnvelopeDirection::Increase ||
-            self.envelope_sweeps == 0 {
+            self.envelope_sweep == 0 {
             return
         }
         self.curr_volume_cycles += cycles;
-        if self.curr_volume_cycles >= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64 {
-            self.curr_volume_cycles %= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64;
+        if self.curr_volume_cycles >= self.envelope_sweep as usize * CYCLES_PER_SECOND / 64 {
+            self.curr_volume_cycles %= self.envelope_sweep as usize * CYCLES_PER_SECOND / 64;
             let vol_adjustment = if self.envelope_direction == EnvelopeDirection::Increase { 1 } else { -1 };
             self.curr_volume = (self.curr_volume as i32 + vol_adjustment) as u8;
         }

--- a/src/audio/channel2.rs
+++ b/src/audio/channel2.rs
@@ -122,6 +122,7 @@ impl Channel2 {
                 if self.restart {
                     self.enabled = true;
                     self.curr_volume = self.initial_volume;
+                    self.curr_volume_cycles = 0;
                     if self.stop_after_sound_length {
                         self.length_counter = MAX_SOUND_LENGTH
                     }

--- a/src/audio/channel2.rs
+++ b/src/audio/channel2.rs
@@ -1,4 +1,4 @@
-use super::{LENGTH_COUNTER_RATE_CYCLES, EnvelopeDirection};
+use super::{CYCLES_PER_SECOND, LENGTH_COUNTER_RATE_CYCLES, EnvelopeDirection};
 
 /// Max length for sound data
 const MAX_SOUND_LENGTH: u8 = 64;
@@ -8,17 +8,18 @@ pub struct Channel2 {
     /// Wave pattern. Bits 6-7 of 0xFF16
     wave_pattern: u8,
 
-    /// Length of sound data. Bits 0-5 of 0xFF16
-    length: u8,
-
-    /// Length counter. Used to tell when to stop playing audio. Sound length is given by 64 - length.
+    /// Length counter. Used to tell when to stop playing audio.
+    /// Sound length is given by 64 - bits 5-0 of 0xFF16.
     length_counter: u8,
 
     /// True if the length counter is enabled
     length_counter_enabled: bool,
 
     /// Volume. Bits 4-7 of 0xFF17
-    volume: u8,
+    initial_volume: u8,
+
+    /// Current volume after being changed by the envelope
+    curr_volume: u8,
 
     /// Envelope direction. Bit 3 of 0xFF17.
     envelope_direction: EnvelopeDirection,
@@ -39,6 +40,9 @@ pub struct Channel2 {
     /// Track current cycles for audio output
     curr_cycles: usize,
 
+    /// Track current cycles for volume envelope sweep
+    curr_volume_cycles: usize,
+
     /// Track current cycles for length counter
     curr_length_counter_cycles: usize,
 
@@ -56,16 +60,17 @@ impl Channel2 {
     pub fn new() -> Channel2 {
         Channel2 {
             wave_pattern: 0,
-            length: 0,
             length_counter: MAX_SOUND_LENGTH,
             length_counter_enabled: true,
-            volume: 0,
+            initial_volume: 0,
+            curr_volume: 0,
             envelope_direction: EnvelopeDirection::Decrease,
             envelope_sweeps: 0,
             frequency: 0,
             restart: false,
             stop_after_sound_length: false,
             curr_cycles: 0,
+            curr_volume_cycles: 0,
             curr_length_counter_cycles: 0,
             curr_index: 0,
             curr_output: 0,
@@ -77,7 +82,7 @@ impl Channel2 {
         match addr {
             0x16 => (self.wave_pattern << 6) | 0b0011_1111, // Low bits are write-only
             0x17 => {
-                self.volume << 4
+                self.initial_volume << 4
                     | (self.envelope_direction as u8) << 3
                     | self.envelope_sweeps
             },
@@ -94,13 +99,12 @@ impl Channel2 {
         match addr {
             0x16 => {
                 self.wave_pattern = val >> 6;
-                self.length = val & 0b0011_1111;
-                self.length_counter = MAX_SOUND_LENGTH - self.length;
+                self.length_counter = MAX_SOUND_LENGTH - (val & 0b0011_1111);
             },
             0x17 => {
                 self.envelope_sweeps = val & 0b0111;
                 self.envelope_direction = EnvelopeDirection::from((val >> 3) & 1);
-                self.volume = val >> 4;
+                self.initial_volume = val >> 4;
             },
             0x18 => {
                 self.frequency &= !0 << 8;
@@ -115,11 +119,12 @@ impl Channel2 {
                 if self.length_counter == 0 && self.restart {
                     self.length_counter = MAX_SOUND_LENGTH;
                 }
-                if self.length_counter_enabled {
-                    self.length_counter = MAX_SOUND_LENGTH
-                }
+                // if self.length_counter_enabled {
+                //     self.length_counter = MAX_SOUND_LENGTH
+                // }
                 if self.restart {
                     self.enabled = true;
+                    self.curr_volume = self.initial_volume;
                     if self.stop_after_sound_length {
                         self.length_counter = MAX_SOUND_LENGTH
                     }
@@ -144,8 +149,9 @@ impl Channel2 {
         }
 
         self.update_length_counter(cycles);
+        self.update_volume(cycles);
 
-        self.curr_output * self.volume
+        self.curr_output * self.curr_volume
     }
 
     fn get_wave_duty(&self) -> u8 {
@@ -162,12 +168,26 @@ impl Channel2 {
         self.curr_length_counter_cycles += cycles;
         if self.curr_length_counter_cycles >= LENGTH_COUNTER_RATE_CYCLES {
             self.curr_length_counter_cycles %= LENGTH_COUNTER_RATE_CYCLES;
-            if self.length_counter > 0 && self.length_counter_enabled {
+            if self.length_counter > 0 && self.stop_after_sound_length {
                 self.length_counter -= 1;
                 if self.length_counter == 0 {
                     self.enabled = false;
                 }
             }
+        }
+    }
+
+    fn update_volume(&mut self, cycles: usize) {
+        if self.curr_volume == 0 && self.envelope_direction == EnvelopeDirection::Decrease ||
+            self.curr_volume == 15 && self.envelope_direction == EnvelopeDirection::Increase ||
+            self.envelope_sweeps == 0 {
+            return
+        }
+        self.curr_volume_cycles += cycles;
+        if self.curr_volume_cycles >= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64 {
+            self.curr_volume_cycles %= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64;
+            let vol_adjustment = if self.envelope_direction == EnvelopeDirection::Increase { 1 } else { -1 };
+            self.curr_volume = (self.curr_volume as i32 + vol_adjustment) as u8;
         }
     }
 }

--- a/src/audio/channel2.rs
+++ b/src/audio/channel2.rs
@@ -25,7 +25,7 @@ pub struct Channel2 {
     envelope_direction: EnvelopeDirection,
 
     /// Number of envelope sweeps. Bits 0-2 of 0xFF17
-    envelope_sweeps: u8,
+    envelope_sweep: u8,
 
     /// Channel frequency. Lower bits are bits 0-7 of 0xFF18. Higher bits are 0-2 of 0xFF19
     /// Actual frequency is given by `(2048 - frequency) * 4`. http://gbdev.gg8.se/wiki/articles/Gameboy_sound_hardware
@@ -65,7 +65,7 @@ impl Channel2 {
             initial_volume: 0,
             curr_volume: 0,
             envelope_direction: EnvelopeDirection::Decrease,
-            envelope_sweeps: 0,
+            envelope_sweep: 0,
             frequency: 0,
             restart: false,
             stop_after_sound_length: false,
@@ -84,7 +84,7 @@ impl Channel2 {
             0x17 => {
                 self.initial_volume << 4
                     | (self.envelope_direction as u8) << 3
-                    | self.envelope_sweeps
+                    | self.envelope_sweep
             },
             0x18 => 0xFF, // This register is entirely write-only
             0x19 => {
@@ -102,7 +102,7 @@ impl Channel2 {
                 self.length_counter = MAX_SOUND_LENGTH - (val & 0b0011_1111);
             },
             0x17 => {
-                self.envelope_sweeps = val & 0b0111;
+                self.envelope_sweep = val & 0b0111;
                 self.envelope_direction = EnvelopeDirection::from((val >> 3) & 1);
                 self.initial_volume = val >> 4;
             },
@@ -119,9 +119,6 @@ impl Channel2 {
                 if self.length_counter == 0 && self.restart {
                     self.length_counter = MAX_SOUND_LENGTH;
                 }
-                // if self.length_counter_enabled {
-                //     self.length_counter = MAX_SOUND_LENGTH
-                // }
                 if self.restart {
                     self.enabled = true;
                     self.curr_volume = self.initial_volume;
@@ -180,12 +177,12 @@ impl Channel2 {
     fn update_volume(&mut self, cycles: usize) {
         if self.curr_volume == 0 && self.envelope_direction == EnvelopeDirection::Decrease ||
             self.curr_volume == 15 && self.envelope_direction == EnvelopeDirection::Increase ||
-            self.envelope_sweeps == 0 {
+            self.envelope_sweep == 0 {
             return
         }
         self.curr_volume_cycles += cycles;
-        if self.curr_volume_cycles >= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64 {
-            self.curr_volume_cycles %= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64;
+        if self.curr_volume_cycles >= self.envelope_sweep as usize * CYCLES_PER_SECOND / 64 {
+            self.curr_volume_cycles %= self.envelope_sweep as usize * CYCLES_PER_SECOND / 64;
             let vol_adjustment = if self.envelope_direction == EnvelopeDirection::Increase { 1 } else { -1 };
             self.curr_volume = (self.curr_volume as i32 + vol_adjustment) as u8;
         }

--- a/src/audio/channel3.rs
+++ b/src/audio/channel3.rs
@@ -156,7 +156,7 @@ impl Channel3 {
         self.curr_length_counter_cycles += cycles;
         if self.curr_length_counter_cycles >= LENGTH_COUNTER_RATE_CYCLES {
             self.curr_length_counter_cycles %= LENGTH_COUNTER_RATE_CYCLES;
-            if self.length_counter > 0 && self.length_counter_enabled {
+            if self.length_counter > 0 && self.stop_after_sound_length {
                 self.length_counter -= 1;
                 if self.length_counter == 0 {
                     self.enabled = false;

--- a/src/audio/channel4.rs
+++ b/src/audio/channel4.rs
@@ -129,6 +129,7 @@ impl Channel4 {
                     self.linear_feedback_shift_register = 0b0111_1111_1111_1111;
                     self.enabled = true;
                     self.curr_volume = self.initial_volume;
+                    self.curr_volume_cycles = 0;
                     if self.stop_after_sound_length {
                         self.length_counter = 64
                     }

--- a/src/audio/channel4.rs
+++ b/src/audio/channel4.rs
@@ -1,21 +1,22 @@
-use super::{EnvelopeDirection, LENGTH_COUNTER_RATE_CYCLES};
+use super::{CYCLES_PER_SECOND, LENGTH_COUNTER_RATE_CYCLES, EnvelopeDirection};
 
 /// Max length for sound data
 const MAX_SOUND_LENGTH: u8 = 64;
 
 #[derive(Clone)]
 pub struct Channel4 {
-    /// Sound Length. Bits 0-5 of 0xFF20
-    length: u8,
-
-    /// Length counter. Used to tell when to stop playing audio. Sound length is given by 64 - length.
+    /// Length counter. Used to tell when to stop playing audio.
+    /// Sound length is given by 64 - bits 5-0 of 0xFF20.
     length_counter: u8,
 
     /// True if the length counter is enabled
     length_counter_enabled: bool,
 
     /// Initial volume of envelope. Bits 4-7 of 0xFF21
-    volume: u8,
+    initial_volume: u8,
+
+    /// Current volume after being changed by the envelope
+    curr_volume: u8,
 
     /// Envelope direction. Bit 3 of 0xFF21
     envelope_direction: EnvelopeDirection,
@@ -47,6 +48,9 @@ pub struct Channel4 {
     /// Track current cycles for audio output
     curr_cycles: usize,
 
+    /// Track current cycles for volume envelope sweep
+    curr_volume_cycles: usize,
+
     /// Track the current audio output value
     curr_output: u8,
 
@@ -57,10 +61,10 @@ pub struct Channel4 {
 impl Channel4 {
     pub fn new() -> Self {
         Self {
-            length: 0,
             length_counter: MAX_SOUND_LENGTH,
             length_counter_enabled: true,
-            volume: 0,
+            initial_volume: 0,
+            curr_volume: 0,
             envelope_direction: EnvelopeDirection::Decrease,
             envelope_sweeps: 0,
             shift_clock_frequency: 0,
@@ -71,6 +75,7 @@ impl Channel4 {
             stop_after_sound_length: false,
             curr_index: 0,
             curr_cycles: 0,
+            curr_volume_cycles: 0,
             curr_output: 0,
             enabled: false,
         }
@@ -80,7 +85,7 @@ impl Channel4 {
         match addr {
             0x20 => 0xFF, // This entire register is write-only
             0x21 => {
-                self.volume << 4
+                self.initial_volume << 4
                     | (self.envelope_direction as u8) << 3
                     | self.envelope_sweeps
             },
@@ -101,13 +106,12 @@ impl Channel4 {
     pub fn write_reg(&mut self, addr: u8, val: u8) {
         match addr {
             0x20 => {
-                self.length = val & 0b0011_1111;
-                self.length_counter = MAX_SOUND_LENGTH - self.length;
+                self.length_counter = MAX_SOUND_LENGTH - (val & 0b0011_1111);
             },
             0x21 => {
                 self.envelope_sweeps = val & 0b0111;
                 self.envelope_direction = EnvelopeDirection::from((val >> 3) & 1);
-                self.volume = val >> 4;
+                self.initial_volume = val >> 4;
             },
             0x22 => {
                 self.dividing_ratio = val & 0b0111;
@@ -127,6 +131,7 @@ impl Channel4 {
                 if self.restart {
                     self.linear_feedback_shift_register = 0b0111_1111_1111_1111;
                     self.enabled = true;
+                    self.curr_volume = self.initial_volume;
                     if self.stop_after_sound_length {
                         self.length_counter = 64
                     }
@@ -150,8 +155,9 @@ impl Channel4 {
         }
 
         self.update_length_counter(cycles);
+        self.update_volume(cycles);
 
-        self.curr_output * self.volume
+        self.curr_output * self.curr_volume
     }
 
     fn get_divisor(&self, dividing_ratio: u8) -> usize {
@@ -186,12 +192,26 @@ impl Channel4 {
         self.curr_cycles += cycles;
         if self.curr_cycles >= LENGTH_COUNTER_RATE_CYCLES {
             self.curr_cycles %= LENGTH_COUNTER_RATE_CYCLES;
-            if self.length_counter > 0 && self.length_counter_enabled {
+            if self.length_counter > 0 && self.stop_after_sound_length {
                 self.length_counter -= 1;
                 if self.length_counter == 0 {
                     self.enabled = false;
                 }
             }
+        }
+    }
+
+    fn update_volume(&mut self, cycles: usize) {
+        if self.curr_volume == 0 && self.envelope_direction == EnvelopeDirection::Decrease ||
+            self.curr_volume == 15 && self.envelope_direction == EnvelopeDirection::Increase ||
+            self.envelope_sweeps == 0 {
+            return
+        }
+        self.curr_volume_cycles += cycles;
+        if self.curr_volume_cycles >= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64 {
+            self.curr_volume_cycles %= self.envelope_sweeps as usize * CYCLES_PER_SECOND / 64;
+            let vol_adjustment = if self.envelope_direction == EnvelopeDirection::Increase { 1 } else { -1 };
+            self.curr_volume = (self.curr_volume as i32 + vol_adjustment) as u8;
         }
     }
 }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -140,17 +140,18 @@ impl Audio {
         }
     }
 
-    pub fn step(&mut self, cycles: usize, audio_queue: &mut sdl2::audio::AudioQueue<u8>) {
+    pub fn step(&mut self, cycles: usize, audio_queue: &mut sdl2::audio::AudioQueue<f32>) {
         let channel1_val = self.channel1.step(cycles);
         let channel2_val = self.channel2.step(cycles);
         let channel3_val = self.channel3.step(cycles);
         let channel4_val = self.channel4.step(cycles);
 
-        let (mut left, mut right) = self.get_left_and_right_audio(channel1_val, channel2_val, channel3_val, channel4_val);
-        left *= self.left_volume;
-        right *= self.right_volume;
+        let (left, right) = self.get_left_and_right_audio(channel1_val, channel2_val, channel3_val, channel4_val);
+        // TODO: revisit master volume
+        let left_float = gb_sample_to_float(left) * (self.left_volume as f32 + 1.0) / 8.0;
+        let right_float = gb_sample_to_float(right) * (self.right_volume as f32 + 1.0) / 8.0;
 
-        self.output_to_queue(left, right, audio_queue, cycles);
+        self.output_to_queue(left_float, right_float, audio_queue, cycles);
     }
 
     fn get_left_and_right_audio(&self, channel1_val: u8, channel2_val: u8, channel3_val: u8, channel4_val: u8) -> (u8, u8) {
@@ -205,7 +206,7 @@ impl Audio {
         ((left / 4) as u8, (right / 4) as u8)
     }
 
-    fn output_to_queue(&mut self, left: u8, right: u8, queue: &mut sdl2::audio::AudioQueue<u8>, cycles: usize) {
+    fn output_to_queue(&mut self, left: f32, right: f32, queue: &mut sdl2::audio::AudioQueue<f32>, cycles: usize) {
         self.queue_cycles += cycles;
         if self.queue_cycles >= SAMPLE_RATE_CYCLES {
             self.queue_cycles %= SAMPLE_RATE_CYCLES;
@@ -229,4 +230,9 @@ impl std::convert::From<u8> for EnvelopeDirection {
             _ => panic!("Invalid u8 value for envelope direction")
         }
     }
+}
+
+// Converts the standard 0 to 15 (4-bit) GB sample to a range of -1.0 to 1.0
+fn gb_sample_to_float(s: u8) -> f32 {
+    -1.0 + (s as f32) * (2.0/15.0)
 }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -9,6 +9,10 @@ use channel3::Channel3;
 use channel4::Channel4;
 use log::warn;
 
+/// CPU cycles per second for the Gamboy
+/// TODO(wcarlson): move this somewhere else?
+const CYCLES_PER_SECOND: usize = 4194304;
+
 /// Number of samples in our audio buffer
 pub const SAMPLE_BUFFER_SIZE: usize = 1024;
 
@@ -211,7 +215,7 @@ impl Audio {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum EnvelopeDirection {
     Decrease = 0,
     Increase = 1,

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -122,7 +122,7 @@ impl Cpu {
 
     /// Keep executing instructions until more than the given number of cycles have passed.
     /// Returns true if we have hit a watch.
-    pub fn step_cycles(&mut self, cycles: usize, audio_queue: &mut AudioQueue<u8>, watches: &HashSet<Watch>) -> bool {
+    pub fn step_cycles(&mut self, cycles: usize, audio_queue: &mut AudioQueue<f32>, watches: &HashSet<Watch>) -> bool {
         let mut curr_cycles: usize = 0;
         let check_watches = watches.len() > 0;
         while curr_cycles < cycles {

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -67,7 +67,7 @@ pub fn start_frontend(cpu: &mut Cpu) {
 
 fn run_emulator(
     cpu: &mut Cpu, canvas: &mut Canvas<Window>, sdl_events: &mut EventPump, sdl_fps: &mut FPSManager,
-    sdl_controllers: &GameControllerSubsystem, controllers: &mut Vec<GameController>, audio_queue: &mut AudioQueue<u8>,
+    sdl_controllers: &GameControllerSubsystem, controllers: &mut Vec<GameController>, audio_queue: &mut AudioQueue<f32>,
     debug: bool, num_instrs: Option<usize>, watches: &HashSet<Watch>
 ) {
     let mut paused = false;


### PR DESCRIPTION
Adds volume and frequency sweeps to rugby. Although still not perfect, this fixes the glaring differences between rugby audio and actual gameboy audio IMO.